### PR TITLE
Change in Signal Naming 

### DIFF
--- a/ApbTestcaseTop.sv
+++ b/ApbTestcaseTop.sv
@@ -13,16 +13,22 @@ module ApbTestcaseTop ();
 
 	ApbTest TC (input_intf, output_intf);
 
-	apb_top uut0 (.PCLK(clk), 
-				  .PRESETn(input_intf.PRESETn), 
-				  .PWRITE(input_intf.PWRITE), 
-				  .PSELx(input_intf.PSELx), 
-				  .PENABLE(input_intf.PENABLE), 
-				  .PADDR(input_intf.PADDR), 
-				  .PWDATA(input_intf.PWDATA), 
-				  .m_rdata(output_intf.m_rdata), 
-				  .m_ready(output_intf.m_ready), 
-				  .m_error(output_intf.m_error)
-				  );
+	apb_top #(
+			.addr_width(4),
+			.data_width(128),
+			.mem_data(8)
+		) inst_apb_top (
+			.PCLK    (clk),
+			.PRESETn (input_intf.PRESETn),
+			.PWRITE  (input_intf.PWRITE),
+			.PSELx   (input_intf.PSELx),
+			.PENABLE (input_intf.PENABLE),
+			.PADDR   (input_intf.PADDR),
+			.PWDATA  (input_intf.PWDATA),
+			.PRDATA  (output_intf.m_rdata),
+			.PREADY  (output_intf.m_ready),
+			.PSLVERR (output_intf.m_error)
+		);
+
 
 endmodule : ApbTestcaseTop

--- a/apb_controller.sv
+++ b/apb_controller.sv
@@ -8,12 +8,12 @@ module apb_controller #(parameter addr_width=4, data_width=128, mem_data=8) (PCL
 	input [data_width-1:0] PWDATA; 									//input data from master to write for controller to be used by slave
 
 	//output to master
-	output reg [mem_data-1:0] PRDATA; 							//output data from controller to be read by master
+	output reg [data_width-1:0] PRDATA; 							//output data from controller to be read by master
 	output reg PREADY, PSLVERR; 						//tranfer of PREADY, PSLVERR and extra ack to show data is received 
 
 	//input from slave
 	input m_ready, m_error;;          								//input response from slave to transfer to master 
-	input [data_width-1:0] m_rdata;  									//input of data from slave to controller to be read by master
+	input [mem_data-1:0] m_rdata;  									//input of data from slave to controller to be read by master
 	
 	//output to slave
 	output reg [(addr_width+4)-1:0] s_addr; 						//output addr from controller to write to in slave

--- a/apb_top.sv
+++ b/apb_top.sv
@@ -1,20 +1,20 @@
 /*`include "apb_controller.sv"
 `include "asyncRam8k_8.sv"*/
 
-module apb_top (PCLK, PRESETn, PWRITE, PSELx, PENABLE, PADDR, PWDATA, m_rdata, m_ready, m_error);
-	input PCLK, PRESETn; 											//
+module apb_top  #(parameter addr_width=4, data_width=128, mem_data=8) (PCLK, PRESETn, PWRITE, PSELx, PENABLE, PADDR, PWDATA, PRDATA, PREADY, PSLVERR);
+	input PCLK, PRESETn; 											
 	input PWRITE, PSELx, PENABLE;  
-	input [apb_c.addr_width-1:0] PADDR;  
-	input [apb_c.data_width-1:0] PWDATA;
+	input [addr_width-1:0] PADDR;  
+	input [data_width-1:0] PWDATA;
 	
 
-	output [apb_c.data_width-1:0] m_rdata; 
-	output m_ready, m_error; 
+	output [data_width-1:0] PRDATA; 
+	output PREADY, PSLVERR; 
 
-	logic [apb_c.data_width-1:0] ram_PRDATA;
+	logic [mem_data-1:0] ram_PRDATA;
 	logic ram_PREADY, ram_PSLVERR;
-	logic [apb_c.addr_width+3:0]s_addr;
-	logic [apb_c.data_width-1:0] s_wdata;  
+	logic [addr_width+3:0]s_addr;
+	logic [mem_data-1:0] s_wdata;  
 	logic s_write, s_cs;
 
 	apb_controller #(.addr_width(4), .data_width(128), .mem_data(8))  apb_c ( .PCLK(PCLK), 
@@ -24,12 +24,12 @@ module apb_top (PCLK, PRESETn, PWRITE, PSELx, PENABLE, PADDR, PWDATA, m_rdata, m
 				                                                             .PENABLE(PENABLE), 
 				                                                             .PADDR(PADDR), 
 				                                                             .PWDATA(PWDATA), 
-				                                                             .PREADY(ram_PREADY), 
-				                                                             .PSLVERR(ram_PSLVERR), 
-				                                                             .PRDATA(ram_PRDATA), 
-				                                                             .m_rdata(m_rdata), 
-				                                                             .m_ready(m_ready), 
-				                                                             .m_error(m_error), 
+				                                                             .PREADY(PREADY), 
+				                                                             .PSLVERR(PSLVERR), 
+				                                                             .PRDATA(PRDATA), 
+				                                                             .m_rdata(ram_PRDATA), 
+				                                                             .m_ready(ram_PREADY), 
+				                                                             .m_error(ram_PSLVERR), 
 				                                                             .s_addr(s_addr), 
 				                                                             .s_wdata(s_wdata), 
 				                                                             .s_write(s_write), 


### PR DESCRIPTION
1. Interchanged the PREADY with m_ready
2. Interchanged the PRDATA with m_rdata
3. Interchanged the PSLVERR with m_error

The above changes are made to align the naming convention with the APB specification sheet.